### PR TITLE
Provide Overrides for Default User

### DIFF
--- a/compose-prod.yml
+++ b/compose-prod.yml
@@ -48,6 +48,9 @@ services:
     image: ethergizmos/shipyard-api:latest
     environment:
       ASPNETCORE_URLS: http://+:8080
+      SHIPYARD_BOOTSTRAP_USER: "${SHIPYARD_BOOTSTRAP_USER:-admin}"
+      SHIPYARD_BOOTSTRAP_PASSWORD: "${SHIPYARD_BOOTSTRAP_PASSWORD:-passowrd}"
+      # SHIPYARD_BOOTSTRAP_FORCE: true
       Database__ConnectionId: ComposeDb
       Connections__ComposeDb__Type: Database
       Connections__ComposeDb__PostgreSql__ConnectionString: Host=db;Database=${POSTGRES_DB:-shipyard};Username=${POSTGRES_USER:-shipyard};Password=${POSTGRES_PASSWORD:-mySecure(!)Password}

--- a/src/EtherGizmos.Shipyard.Api/Services/HostedServices/InitialConfigSeeder.cs
+++ b/src/EtherGizmos.Shipyard.Api/Services/HostedServices/InitialConfigSeeder.cs
@@ -6,11 +6,14 @@ namespace EtherGizmos.Shipyard.Api.Services.HostedServices;
 
 public class InitialConfigSeeder : IHostedService
 {
+    private readonly IConfiguration _configuration;
     private readonly IUnitOfWorkFactory _uowFactory;
 
     public InitialConfigSeeder(
+        IConfiguration configuration,
         IUnitOfWorkFactory uowFactory)
     {
+        _configuration = configuration;
         _uowFactory = uowFactory;
     }
 
@@ -19,16 +22,21 @@ public class InitialConfigSeeder : IHostedService
         using var uow = _uowFactory.Create();
         var userRepo = uow.Repository<User>();
 
-        if (!await userRepo.Data.AnyAsync(cancellationToken: cancellationToken))
-        {
-            var user = new User()
-            {
-                Username = "admin",
-                FullName = "Admin",
-                Password = "password",
-            };
+        var forceCreate = _configuration.GetValue<string>("SHIPYARD_BOOTSTRAP_FORCE")?.ToLower() == "true";
+        var username = _configuration.GetValue<string>("SHIPYARD_BOOTSTRAP_USER") ?? "admin";
+        var password = _configuration.GetValue<string>("SHIPYARD_BOOTSTRAP_PASSWORD") ?? "password";
 
-            userRepo.Create(user);
+        var user = await userRepo.Data.SingleOrDefaultAsync(e => e.Username == username, cancellationToken: cancellationToken);
+        if (!await userRepo.Data.AnyAsync(cancellationToken: cancellationToken) || forceCreate)
+        {
+            if (user is null)
+            {
+                user ??= new User();
+                userRepo.Create(user);
+            }
+
+            user.Username = username;
+            user.Password = password;
 
             await uow.SaveChangesAsync(cancellationToken);
         }


### PR DESCRIPTION
Adds the environment variables `SHIPYARD_BOOTSTRAP_USER` and `SHIPYARD_BOOTSTRAP_PASSWORD`, which can be used to override the default admin credentials.