### PR TITLE
Dockerize Build Artifacts

### DIFF
--- a/azure-pipelines-audit.yml
+++ b/azure-pipelines-audit.yml
@@ -18,7 +18,7 @@ resources:
   - repository: sharedTemplates
     type: git
     name: 'Projects/PipelineTemplates'
-    ref: 'refs/tags/1.1.0'
+    ref: 'refs/tags/1.2.0'
 
 stages:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,4 +134,9 @@ stages:
       inputArtifactName: 'web'
       outputArtifactName: 'web-docker'
       dockerfilePath: 'containers/web.dockerfile'
+      extraFiles:
+      - from: 'containers/apply-config-env.js'
+        to: ''
+      - from: 'containers/docker-entrypoint.web.sh'
+        to: ''
       repository: 'shipyard-web'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ stages:
           workingDir: './src/EtherGizmos.Shipyard.Api/wwwroot/_src'
 
   # Publish dotnet api (docker)
-  - template: shared/container/dockerize-artifact@sharedTemplates
+  - template: shared/container/dockerize-artifact.yml@sharedTemplates
     parameters:
       name: 'publish_dotnet_api_docker'
       dependsOn:
@@ -103,7 +103,7 @@ stages:
       artifactName: 'worker'
 
   # Publish dotnet worker (docker)
-  - template: shared/container/dockerize-artifact@sharedTemplates
+  - template: shared/container/dockerize-artifact.yml@sharedTemplates
     parameters:
       name: 'publish_dotnet_worker_docker'
       dependsOn:
@@ -126,7 +126,7 @@ stages:
       artifactName: 'web'
 
   # Publish angular web ui (docker)
-  - template: shared/container/dockerize-artifact@sharedTemplates
+  - template: shared/container/dockerize-artifact.yml@sharedTemplates
     parameters:
       name: 'publish_node_webui_docker'
       dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ resources:
   - repository: sharedTemplates
     type: git
     name: 'Projects/PipelineTemplates'
-    ref: 'refs/tags/1.1.0'
+    ref: 'refs/heads/feature/dockerize'
 
 stages:
 
@@ -83,6 +83,17 @@ stages:
           command: 'ci'
           workingDir: './src/EtherGizmos.Shipyard.Api/wwwroot/_src'
 
+  # Publish dotnet api (docker)
+  - template: shared/container/dockerize-artifact@sharedTemplates
+    parameters:
+      name: 'publish_dotnet_api_docker'
+      dependsOn:
+      - 'publish_dotnet_api'
+      inputArtifactName: 'api'
+      outputArtifactName: 'api-docker'
+      dockerfilePath: 'containers/api.dockerfile'
+      repository: 'shipyard-api'
+
   # Publish dotnet worker
   - template: dotnet/publish/application.yml@sharedTemplates
     parameters:
@@ -90,6 +101,17 @@ stages:
       vmImage: 'ubuntu-22.04'
       projectName: 'EtherGizmos.Shipyard.Worker'
       artifactName: 'worker'
+
+  # Publish dotnet worker (docker)
+  - template: shared/container/dockerize-artifact@sharedTemplates
+    parameters:
+      name: 'publish_dotnet_worker_docker'
+      dependsOn:
+      - 'publish_dotnet_worker'
+      inputArtifactName: 'worker'
+      outputArtifactName: 'worker-docker'
+      dockerfilePath: 'containers/worker.dockerfile'
+      repository: 'shipyard-worker'
 
   # Publish angular web ui
   - template: node/publish/application.yml@sharedTemplates
@@ -102,3 +124,14 @@ stages:
       distFolder: 'dist'
       projectName: 'EtherGizmos.Shipyard.Web'
       artifactName: 'web'
+
+  # Publish angular web ui (docker)
+  - template: shared/container/dockerize-artifact@sharedTemplates
+    parameters:
+      name: 'publish_node_webui_docker'
+      dependsOn:
+      - 'publish_node_webui'
+      inputArtifactName: 'web'
+      outputArtifactName: 'web-docker'
+      dockerfilePath: 'containers/web.dockerfile'
+      repository: 'shipyard-web'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ resources:
   - repository: sharedTemplates
     type: git
     name: 'Projects/PipelineTemplates'
-    ref: 'refs/heads/feature/dockerize'
+    ref: 'refs/tags/1.2.0'
 
 stages:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ stages:
       dockerfilePath: 'containers/web.dockerfile'
       extraFiles:
       - from: 'containers/apply-config-env.js'
-        to: ''
+        to: 'files'
       - from: 'containers/docker-entrypoint.web.sh'
-        to: ''
+        to: 'files'
       repository: 'shipyard-web'

--- a/containers/api.dockerfile
+++ b/containers/api.dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0
 
 WORKDIR /app
 
-COPY containers/deploy/api/. ./
+COPY app/ .
 
 EXPOSE 8080
 

--- a/containers/web.dockerfile
+++ b/containers/web.dockerfile
@@ -7,8 +7,8 @@ RUN npm install -g pm2 serve
 COPY app/ether-gizmos.shipyard.web/browser/ ./browser
 RUN cp ./browser/assets/config.json ./browser/assets/config.base.json
 
-COPY apply-config-env.js /opt/apply-config-env.js
-COPY docker-entrypoint.web.sh /docker-entrypoint.sh
+COPY files/apply-config-env.js /opt/apply-config-env.js
+COPY files/docker-entrypoint.web.sh /docker-entrypoint.sh
 RUN sed -i 's/\r$//' /docker-entrypoint.sh /opt/apply-config-env.js \
   && chmod +x /docker-entrypoint.sh
 

--- a/containers/web.dockerfile
+++ b/containers/web.dockerfile
@@ -4,11 +4,11 @@ WORKDIR /app
 
 RUN npm install -g pm2 serve
 
-COPY containers/deploy/web/ether-gizmos.shipyard.web/browser/. ./browser
+COPY app/ether-gizmos.shipyard.web/browser/ ./browser
 RUN cp ./browser/assets/config.json ./browser/assets/config.base.json
 
-COPY containers/apply-config-env.js /opt/apply-config-env.js
-COPY containers/docker-entrypoint.web.sh /docker-entrypoint.sh
+COPY apply-config-env.js /opt/apply-config-env.js
+COPY docker-entrypoint.web.sh /docker-entrypoint.sh
 RUN sed -i 's/\r$//' /docker-entrypoint.sh /opt/apply-config-env.js \
   && chmod +x /docker-entrypoint.sh
 

--- a/containers/worker.dockerfile
+++ b/containers/worker.dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0
 
 WORKDIR /app
 
-COPY containers/deploy/worker/. ./
+COPY app/ .
 
 EXPOSE 8080
 


### PR DESCRIPTION
Utilizes a new template to Dockerize the existing published artifacts. This will group the Dockerfile with the compiled application, enabling a more straightforward publishing process.