### PR TITLE
Add Expanded Connections Configuration Provider

### DIFF
--- a/src/EtherGizmos.Common.Configuration/IConfigurationBuilderExtensions.cs
+++ b/src/EtherGizmos.Common.Configuration/IConfigurationBuilderExtensions.cs
@@ -17,4 +17,16 @@ public static class IConfigurationBuilderExtensions
 
         return @this;
     }
+
+    public static IConfigurationBuilder AddExpandedConnections(
+        this IConfigurationBuilder @this,
+        IConfigurationRoot configuration)
+    {
+        @this.Add(new ExpandedConnectionsVariablesConfigurationSource()
+        {
+            Configuration = configuration,
+        });
+
+        return @this;
+    }
 }

--- a/src/EtherGizmos.Common.Configuration/Providers/ExpandedConnectionsVariablesConfigurationProvider.cs
+++ b/src/EtherGizmos.Common.Configuration/Providers/ExpandedConnectionsVariablesConfigurationProvider.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace EtherGizmos.Common.Providers;
+
+internal class ExpandedConnectionsVariablesConfigurationProvider : ConfigurationProvider
+{
+    private IConfigurationRoot _configuration;
+
+    private static readonly IEnumerable<string> _databases =
+    [
+        "PostgreSql",
+    ];
+
+    private static readonly IEnumerable<string> _certificates =
+    [
+        "File",
+        "Text",
+    ];
+
+    public ExpandedConnectionsVariablesConfigurationProvider(
+        IConfigurationRoot configuration)
+    {
+        _configuration = new ConfigurationRoot([.. configuration.Providers]);
+
+        //Monitor for changes in the underlying configuration
+        ChangeToken.OnChange(
+            () => _configuration.GetReloadToken(),
+            () =>
+            {
+                //Reload settings, then mark them as reloaded
+                Load();
+                OnReload();
+            });
+    }
+
+    public override void Load()
+    {
+        Data.Clear();
+
+        var values = _configuration
+            .AsEnumerable()
+            .ToList();
+
+        foreach (var database in _databases)
+        {
+            var marker = $":{database}:";
+
+            var matches = values
+                .Where(e => e.Key.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var prefixes = matches
+                .Select(e => e.Key.Substring(0, e.Key.IndexOf(marker, StringComparison.OrdinalIgnoreCase)))
+                .Distinct();
+
+            foreach (var prefix in prefixes)
+            {
+                var connectionId = Guid.NewGuid().ToString();
+                Data[$"{prefix}:ConnectionId"] = connectionId;
+                Data[$"Connections:{connectionId}:Type"] = "Database";
+
+                foreach (var match in matches.Where(e => e.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var newKey = match.Key.Substring(prefix.Length);
+                    Data[$"Connections:{connectionId}{newKey}"] = match.Value;
+                }
+            }
+        }
+
+        foreach (var certificate in _certificates)
+        {
+            var marker = $":{certificate}:";
+
+            var matches = values
+                .Where(e => e.Key.Contains(marker, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var prefixes = matches
+                .Select(e => e.Key.Substring(0, e.Key.IndexOf(marker, StringComparison.OrdinalIgnoreCase)))
+                .Distinct();
+
+            foreach (var prefix in prefixes)
+            {
+                var certificateId = Guid.NewGuid().ToString();
+                Data[$"{prefix}:CertificateId"] = certificateId;
+                Data[$"Security:Certificates:{certificateId}:Type"] = "Certificate";
+
+                foreach (var match in matches.Where(e => e.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var newKey = match.Key.Substring(prefix.Length);
+                    Data[$"Security:Certificates:{certificateId}{newKey}"] = match.Value;
+                }
+            }
+        }
+    }
+}

--- a/src/EtherGizmos.Common.Configuration/Providers/ExpandedConnectionsVariablesConfigurationSource.cs
+++ b/src/EtherGizmos.Common.Configuration/Providers/ExpandedConnectionsVariablesConfigurationSource.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace EtherGizmos.Common.Providers;
+
+internal class ExpandedConnectionsVariablesConfigurationSource : IConfigurationSource
+{
+    public IConfigurationRoot Configuration { get; set; } = null!;
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        return new ExpandedConnectionsVariablesConfigurationProvider(Configuration);
+    }
+}

--- a/src/EtherGizmos.Shipyard.Api/Program.cs
+++ b/src/EtherGizmos.Shipyard.Api/Program.cs
@@ -41,7 +41,8 @@ builder.Configuration
     .AddRemappedEnvironmentVariables(
         (new(@"(?<=[^:_])_(?=[^_])"), "."),
         (new(@"(?<=[^_]):_(?=[^_])"), " "),
-        (new(@"^ConnectionStrings:(?=[^_:])"), ""));
+        (new(@"^ConnectionStrings:(?=[^_:])"), ""))
+    .AddExpandedConnections(builder.Configuration);
 
 builder.Services
     .AddOptions<DatabaseReferenceOptions>()

--- a/src/EtherGizmos.Shipyard.Worker/Program.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Program.cs
@@ -34,7 +34,8 @@ builder.Configuration
     .AddRemappedEnvironmentVariables(
         (new(@"(?<=[^:_])_(?=[^_])"), "."),
         (new(@"(?<=[^_]):_(?=[^_])"), " "),
-        (new(@"^ConnectionStrings:(?=[^_:])"), ""));
+        (new(@"^ConnectionStrings:(?=[^_:])"), ""))
+    .AddExpandedConnections(builder.Configuration);
 
 builder.Services
     .AddOptions<DatabaseReferenceOptions>()

--- a/tests/EtherGizmos.Shipyard.Api.IntegrationTests/Setup.cs
+++ b/tests/EtherGizmos.Shipyard.Api.IntegrationTests/Setup.cs
@@ -51,9 +51,7 @@ internal static class Setup
         {
             ["Artifacts:BasePath"] = "artifacts",
             ["Artifacts:Database:ConnectionId"] = "TestDb",
-            ["Connections:TestDb:Type"] = "Database",
-            ["Connections:TestDb:PostgreSql:ConnectionString"] = _pgsqlCstr,
-            ["Database:ConnectionId"] = "TestDb",
+            ["Database:PostgreSql:ConnectionString"] = _pgsqlCstr,
             ["RabbitMq:ConnectionString"] = _rmqCstr,
             ["Security:Certificates:AuthSigning:Type"] = "Certificate",
             ["Security:Certificates:AuthSigning:Text:PublicKey"] = Certificates.TokenSigningPublicKey,


### PR DESCRIPTION
Adds a configuration provider that converts a basic connection string to the verbose connection id style. This also applies to certificates. There is room to apply this to email and messages, but those systems need some additional development before they will be ready for this.