### PR TITLE
Add Related Record Links

### DIFF
--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.html
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.html
@@ -69,13 +69,28 @@
             </label>
             <div class="col-sm-8">
               @if (canViewCarriers$$()) {
-              <ng-select id="carrierId" formControlName="carrierId" [readonly]="!isEditing$$()" [readonlyForm]="!isEditing$$()">
-                @for (carrier of carriers$$(); track carrier.id) {
-                <ng-option [value]="carrier.id">
-                  {{carrier.name}}
-                </ng-option>
+              <div class="row align-items-center">
+                <div class="col">
+                  <ng-select id="carrierId"
+                             formControlName="carrierId"
+                             [clearable]="false"
+                             [readonly]="!isEditing$$()"
+                             [readonlyForm]="!isEditing$$()">
+                    @for (carrier of carriers$$(); track carrier.id) {
+                    <ng-option [value]="carrier.id">
+                      {{carrier.name}}
+                    </ng-option>
+                    }
+                  </ng-select>
+                </div>
+                @if (!isEditing$$()) {
+                <div class="col-auto">
+                  <a [routerLink]="['/carriers', record.carrierId]" [queryParams]="{append: 1}">
+                    <span class="bi bi-box-arrow-up-right"></span>
+                  </a>
+                </div>
                 }
-              </ng-select>
+              </div>
               } @else {
               <div ngbTooltip="You don't have permission to view or change carriers.">
                 <input type="text" readonly class="form-control-plaintext" value="(Hidden — insufficient permissions)" />

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, inject, OnInit, signal } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EntitySingle } from '@ethergizmos/odata-fluent-client';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { DetailBoxComponent } from '../../../../shared/components/detail-box/detail-box.component';
@@ -28,6 +28,7 @@ import { PackageService } from '../../services/package/package.service';
     NgSelectModule,
     ReactiveFormsModule,
     ReadonlyFormDirective,
+    RouterModule,
   ],
   templateUrl: './package-detail.component.html',
   styleUrl: './package-detail.component.scss'

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/user/pages/user-detail/user-detail.component.html
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/user/pages/user-detail/user-detail.component.html
@@ -125,17 +125,28 @@
             </label>
             <div class="col-sm-8">
               @if (canViewGroups$$()) {
-              <ng-select id="groupId"
-                         formControlName="groupId"
-                         [clearable]="false"
-                         [readonly]="!isEditing$$()"
-                         [readonlyForm]="!isEditing$$()">
-                @for (group of groups$$(); track group.id) {
-                <ng-option [value]="group.id">
-                  {{group.name}}
-                </ng-option>
+              <div class="row align-items-center">
+                <div class="col">
+                  <ng-select id="groupId"
+                             formControlName="groupId"
+                             [clearable]="false"
+                             [readonly]="!isEditing$$()"
+                             [readonlyForm]="!isEditing$$()">
+                    @for (group of groups$$(); track group.id) {
+                    <ng-option [value]="group.id">
+                      {{group.name}}
+                    </ng-option>
+                    }
+                  </ng-select>
+                </div>
+                @if (!isEditing$$()) {
+                <div class="col-auto">
+                  <a [routerLink]="['/groups', record.groupId]" [queryParams]="{append: 1}">
+                    <span class="bi bi-box-arrow-up-right"></span>
+                  </a>
+                </div>
                 }
-              </ng-select>
+              </div>
               } @else {
               <div ngbTooltip="You don't have permission to view or change groups.">
                 <input type="text" readonly class="form-control-plaintext" value="(Hidden — insufficient permissions)" />

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/user/pages/user-detail/user-detail.component.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/user/pages/user-detail/user-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EntitySingle } from '@ethergizmos/odata-fluent-client';
 import { parseGuid } from '@ethergizmos/odata-fluent-client/dist/src/types/guid';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
@@ -34,6 +34,7 @@ import { UserService } from '../../services/user/user.service';
     NgSelectModule,
     ReactiveFormsModule,
     ReadonlyFormDirective,
+    RouterModule,
   ],
   templateUrl: './user-detail.component.html',
   styleUrl: './user-detail.component.scss'


### PR DESCRIPTION
Adds links to related records on applicable pages, including packages and users. These allow viewing the related record when not editing the current record. The breadcrumbs should remember the previous page and allow navigating back.