### PR TITLE
Fix Tracking Updates Capturing Incorrect Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Values in `.env` will override those in `compose.yml`.
 | SHIPYARD_API_PORT           | The port on which to run the Shipyard API.           | 7448                                  |
 | SHIPYARD_WEB_HOST           | The base URL hosting Shipyard UI.                    | http://localhost:7447                 |
 | SHIPYARD_WEB_PORT           | The port on which to run the Shipyard UI.            | 7447                                  |
+| SHIPYARD_DEFAULT_TZ         | The default IANA time zone for the app.              | America/Chicago                       |
 | SHIPYARD_ENC_TYPE           | How to load the encryption certificate: File or Text | File                                  |
 | SHIPYARD_ENC_PATH           | If File, the path to the encryption certificate      | /opt/certificates/auth-encryption.pfx |
 | SHIPYARD_ENC_CRT            | TEMP; if Text, encryption public key (.crt)          | (a certificate)                       |

--- a/compose.yml
+++ b/compose.yml
@@ -100,6 +100,7 @@ services:
       Connections__ComposeDb__PostgreSql__ConnectionString: Host=db;Database=${POSTGRES_DB:-shipyard};Username=${POSTGRES_USER:-shipyard};Password=${POSTGRES_PASSWORD:-mySecure(!)Password}
       RabbitMq__ConnectionString: amqp://${RABBITMQ_USER:-shipyard}:${RABBITMQ_PASSWORD:-mySecure(!)Password}@rmq:5672
       Selenium__ConnectionString: http://selenium:4444/wd/hub
+      Worker__DefaultTimeZone: ${SHIPYARD_DEFAULT_TZ:-America/Chicago}
       # Connections__MySmtp__Type: Email
       # Connections__MySmtp__Smtp__Host: "${SMTP_HOST}"
       # Connections__MySmtp__Smtp__Port: "${SMTP_PORT}"

--- a/src/EtherGizmos.Shipyard.Notifications/IServiceCollectionExtensions.cs
+++ b/src/EtherGizmos.Shipyard.Notifications/IServiceCollectionExtensions.cs
@@ -59,6 +59,11 @@ public static class IServiceCollectionExtensions
                     .AddScoped(iemailSender, services =>
                     {
                         var (connectionId, connection) = services.GetEmailConnection();
+                        if (connectionId == "<invalid>")
+                            return typeof(NullEmailNotificationSender<>)
+                                .MakeGenericType(@event)
+                                .GetConstructor([])!
+                                .Invoke([]);
 
                         return connection.Match(
                             _ => throw new InvalidOperationException($"The connection {connectionId} is not a valid email connection."),
@@ -89,14 +94,22 @@ public static class IServiceCollectionExtensions
     private static (string Id, OneOfEmailConnection Connection) GetEmailConnection(
         this IServiceProvider @this)
     {
-        var notifOptions = @this.GetRequiredService<IOptions<NotificationOptions>>()
+        var notifOptions = @this
+            .GetRequiredService<IOptions<NotificationOptions>>()
             .Value;
 
-        var connectionId = notifOptions.Email.ConnectionId;
+        if (notifOptions.IsEnabled && notifOptions.Email.IsEnabled)
+        {
+            var connectionId = notifOptions.Email.ConnectionId;
 
-        var resolver = @this.GetRequiredService<IConnectionResolver>();
-        var connection = resolver.GetEmailConnection(connectionId);
+            var resolver = @this.GetRequiredService<IConnectionResolver>();
+            var connection = resolver.GetEmailConnection(connectionId);
 
-        return (connectionId, connection);
+            return (connectionId, connection);
+        }
+        else
+        {
+            return ("<invalid>", new OneOfEmailConnection(new EmailConnectionOptions()));
+        }
     }
 }

--- a/src/EtherGizmos.Shipyard.Notifications/Services/NullEmailNotificationSender.cs
+++ b/src/EtherGizmos.Shipyard.Notifications/Services/NullEmailNotificationSender.cs
@@ -1,0 +1,10 @@
+﻿using EtherGizmos.Shipyard.Models;
+
+namespace EtherGizmos.Shipyard.Services;
+
+internal class NullEmailNotificationSender<TEvent> : IEmailNotificationSender<TEvent>
+    where TEvent : NotificationEvent
+{
+    public Task NotifyAsync(TEvent notification, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/carrier/pages/carrier-detail/carrier-detail.component.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/carrier/pages/carrier-detail/carrier-detail.component.ts
@@ -135,11 +135,13 @@ export class CarrierDetailComponent {
   readonly execButtons$$ = computed<DetailBoxButton[]>(() => {
     const buttons: DetailBoxButton[] = [];
 
-    buttons.push({
-      color: "primary",
-      text: "View all",
-      callback: this.viewExecutions,
-    });
+    if (!this.isEditing$$()) {
+      buttons.push({
+        color: "primary",
+        text: "View all",
+        callback: this.viewExecutions,
+      });
+    }
 
     return buttons;
   });

--- a/src/EtherGizmos.Shipyard.Web/src/main.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/main.ts
@@ -132,10 +132,7 @@ declare global {
   function selectAll(selector: string): TransformNode[];
   function selectOne(selector: string): TransformNode | null;
 
-  function parseDate(text: string, format: string, tz?: string): Instant;
-  function regexMatch(text: string, pattern: string): string[] | null;
-  function normalize(text: string): string;
-  function hash(text: string): string;
+  function parseDate(text: string, location: string): string;
 
   function recordEvent(event: TrackingEvent): void;
   function setEta(at: Timestamp): void;

--- a/src/EtherGizmos.Shipyard.Worker/Configuration/WorkerOptions.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Configuration/WorkerOptions.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Options;
+using System.ComponentModel.DataAnnotations;
+
+namespace EtherGizmos.Shipyard.Worker.Configuration;
+
+public class WorkerOptions : IValidateOptions<WorkerOptions>
+{
+    [Required]
+    public string DefaultTimeZone { get; set; } = null!;
+
+    public string? ContainerTimeZone { get; set; }
+
+    public ValidateOptionsResult Validate(
+        string? name,
+        WorkerOptions options)
+    {
+        if (!TimeZoneInfo.TryFindSystemTimeZoneById(options.DefaultTimeZone, out _))
+            return ValidateOptionsResult.Fail($"The value {options.DefaultTimeZone} is not a valid IANA time zone");
+
+        if (!string.IsNullOrWhiteSpace(options.ContainerTimeZone) && !TimeZoneInfo.TryFindSystemTimeZoneById(options.ContainerTimeZone, out _))
+            return ValidateOptionsResult.Fail($"The value {options.ContainerTimeZone} is not a valid IANA time zone");
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/EtherGizmos.Shipyard.Worker/Configuration/WorkerOptions.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Configuration/WorkerOptions.cs
@@ -8,17 +8,12 @@ public class WorkerOptions : IValidateOptions<WorkerOptions>
     [Required]
     public string DefaultTimeZone { get; set; } = null!;
 
-    public string? ContainerTimeZone { get; set; }
-
     public ValidateOptionsResult Validate(
         string? name,
         WorkerOptions options)
     {
         if (!TimeZoneInfo.TryFindSystemTimeZoneById(options.DefaultTimeZone, out _))
             return ValidateOptionsResult.Fail($"The value {options.DefaultTimeZone} is not a valid IANA time zone");
-
-        if (!string.IsNullOrWhiteSpace(options.ContainerTimeZone) && !TimeZoneInfo.TryFindSystemTimeZoneById(options.ContainerTimeZone, out _))
-            return ValidateOptionsResult.Fail($"The value {options.ContainerTimeZone} is not a valid IANA time zone");
 
         return ValidateOptionsResult.Success;
     }

--- a/src/EtherGizmos.Shipyard.Worker/Consumers/TrackingResponseConsumer.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Consumers/TrackingResponseConsumer.cs
@@ -36,7 +36,10 @@ public class TrackingResponseConsumer : IMessageConsumer<TrackingResponse>
         var message = context.Message;
         _logger.LogInformation("Received response message {@Message}", message);
 
-        var package = await packageRepo.Data.SingleAsync(e => e.Id == message.PackageId, cancellationToken: context.CancellationToken);
+        var package = await packageRepo.Data
+            .Include(e => e.Carrier)
+            .Include(e => e.TrackingUpdates)
+            .SingleAsync(e => e.Id == message.PackageId, cancellationToken: context.CancellationToken);
 
         var executionRepo = uow.Repository<CarrierExecution>();
         var execution = await executionRepo.Data.SingleOrDefaultAsync(e => e.Id == message.ExecutionId, cancellationToken: context.CancellationToken);

--- a/src/EtherGizmos.Shipyard.Worker/Program.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Program.cs
@@ -67,6 +67,16 @@ builder.Services
     .ValidateDataAnnotations()
     .ValidateOnStart();
 
+builder.Services
+    .AddOptions<WorkerOptions>()
+    .Configure<IConfiguration>((opt, conf) =>
+    {
+        conf.GetSection("Worker")
+            .Bind(opt);
+    })
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
 //************************************************************
 // Services
 

--- a/src/EtherGizmos.Shipyard.Worker/Services/Carriers/RunbookBrowserTrackingProvider.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Services/Carriers/RunbookBrowserTrackingProvider.cs
@@ -80,7 +80,7 @@ internal class RunbookBrowserTrackingProvider : ITrackingProvider, IDisposable
         var artifacts = new List<TrackingResultArtifact>();
 
         var index = 0;
-        ApplyLogger(runbook);
+        ApplyServices(runbook);
         foreach (var step in runbook)
         {
             step.Index = ++index;
@@ -179,16 +179,17 @@ internal class RunbookBrowserTrackingProvider : ITrackingProvider, IDisposable
         return result;
     }
 
-    private void ApplyLogger(
+    private void ApplyServices(
         IEnumerable<ScrapingStep> steps)
     {
         foreach (var step in steps)
         {
+            step.ServiceProvider = _serviceProvider;
             step.Logger = _logger;
 
             if (step is ExtractListStep extractStep)
             {
-                ApplyLogger(extractStep.Steps);
+                ApplyServices(extractStep.Steps);
             }
         }
     }

--- a/src/EtherGizmos.Shipyard.Worker/Services/Carriers/Scraping/ScrapingStep.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Services/Carriers/Scraping/ScrapingStep.cs
@@ -15,6 +15,8 @@ public abstract class ScrapingStep
 
     internal int Index { get; set; }
 
+    internal IServiceProvider ServiceProvider { get; set; } = null!;
+
     internal ILogger Logger { get; set; } = NullLogger.Instance;
 
     internal DateTimeOffset? Eta => _eta;

--- a/src/EtherGizmos.Shipyard.Worker/Services/Carriers/Scraping/ScriptStep.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Services/Carriers/Scraping/ScriptStep.cs
@@ -1,4 +1,5 @@
 ﻿using EtherGizmos.Common.Extensions;
+using EtherGizmos.Shipyard.Worker.Configuration;
 using EtherGizmos.Shipyard.Worker.Services.WebDrivers;
 using HtmlAgilityPack;
 using HtmlAgilityPack.CssSelectors.NetCore;
@@ -7,7 +8,9 @@ using Jint.Native;
 using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 
@@ -23,7 +26,7 @@ internal class ScriptStep : ScrapingStep
     public override async Task Apply(IBrowserClient client, IDictionary<string, object> variables, IDictionary<string, object> results, CancellationToken cancellationToken = default)
     {
         var html = await client.GetHtmlAsync(cancellationToken);
-        var result = ScriptTransform.Run(html, Script, Logger);
+        var result = ScriptTransform.Run(html, Script, ServiceProvider, Logger);
 
         if (result.EstimatedDeliveryAt is not null)
         {
@@ -170,7 +173,7 @@ internal class ScriptStep : ScrapingStep
 
     public static class ScriptTransform
     {
-        public static TrackingResult Run(string html, string js, ILogger logger)
+        public static TrackingResult Run(string html, string js, IServiceProvider serviceProvider, ILogger logger)
         {
             var snapshot = HapSnapshot.FromHtml(html);
             var host = new HapHost(snapshot, logger);
@@ -301,6 +304,48 @@ internal class ScriptStep : ScrapingStep
                 });
             }));
 
+            engine.SetValue("normalizeLocalDate", (Func<int, int, int, int, int, int, string?, JsValue>)((a, b, c, d, e, f, g) =>
+            {
+                var result = NormalizeLocalDate(serviceProvider, a, b, c, d, e, f, g);
+                return JsValue.FromObject(engine, result);
+            }));
+
+            engine.Execute("""
+                function normalizeDateString(input) {
+                    if (!input) return input;
+
+                    let s = input.trim();
+
+                    //Collapse whitespace
+                    s = s.replace(/\s+/g, " ");
+
+                    //Normalize A.M. / P.M. → AM / PM
+                    s = s.replace(/A\.M\./gi, "AM")
+                         .replace(/P\.M\./gi, "PM");
+
+                    return s;
+                }
+
+                function parseDate(input, location) {
+                    const normalized = normalizeDateString(input);
+                    const date = new Date(normalized);
+                    console.log("Produced date", date, "from", input, "with ISO", date.toISOString());
+
+                    if (isNaN(date.getTime())) {
+                        throw new Error("Could not parse date: " + input);
+                    }
+
+                    const year = date.getFullYear();
+                    const month = date.getMonth() + 1; //For whatever reason, months are 0-indexed
+                    const day = date.getDate();
+                    const hour = date.getHours();
+                    const minute = date.getMinutes();
+                    const second = date.getSeconds();
+
+                    return normalizeLocalDate(year, month, day, hour, minute, second, location ?? null);
+                }
+                """);
+
             var console = engine.Intrinsics.Object.Construct(Arguments.Empty);
 
             console.Set("log", new ClrFunction(engine, "log", (thisObj, args) =>
@@ -336,5 +381,43 @@ internal class ScriptStep : ScrapingStep
                 Artifacts = [],
             };
         }
+    }
+
+    private static string NormalizeLocalDate(
+        IServiceProvider serviceProvider,
+        int year,
+        int month,
+        int day,
+        int hour,
+        int minute,
+        int second,
+        string? location)
+    {
+        var options = serviceProvider
+            .GetRequiredService<IOptionsMonitor<WorkerOptions>>()
+            .CurrentValue;
+
+        // 1. Interpret this as a wall-clock time in the *target* time zone
+        var localWallClock = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Unspecified);
+
+        var targetTz = ResolveTimeZone(serviceProvider, location); // e.g. DefaultTimeZone = "America/Chicago"
+
+        // 2. Convert FROM target time zone TO UTC
+        var utc = TimeZoneInfo.ConvertTimeToUtc(localWallClock, targetTz);
+
+        // 3. Return an ISO 8601 UTC string
+        var dateString = utc.ToString("O");
+        return dateString;
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(
+        IServiceProvider serviceProvider,
+        string? location)
+    {
+        var options = serviceProvider
+            .GetRequiredService<IOptionsMonitor<WorkerOptions>>()
+            .CurrentValue;
+
+        return TimeZoneInfo.FindSystemTimeZoneById(options.DefaultTimeZone);
     }
 }

--- a/src/EtherGizmos.Shipyard.Worker/appsettings.Development.json
+++ b/src/EtherGizmos.Shipyard.Worker/appsettings.Development.json
@@ -8,6 +8,9 @@
       "ConnectionId": "AspireDb"
     }
   },
+  "Worker": {
+    "ContainerTimeZone": "Etc/UTC"
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.OpenTelemetry" ],
     "WriteTo": [

--- a/src/EtherGizmos.Shipyard.Worker/appsettings.Development.json
+++ b/src/EtherGizmos.Shipyard.Worker/appsettings.Development.json
@@ -8,9 +8,6 @@
       "ConnectionId": "AspireDb"
     }
   },
-  "Worker": {
-    "ContainerTimeZone": "Etc/UTC"
-  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.OpenTelemetry" ],
     "WriteTo": [

--- a/src/EtherGizmos.Shipyard.Worker/appsettings.json
+++ b/src/EtherGizmos.Shipyard.Worker/appsettings.json
@@ -8,6 +8,9 @@
   "Notifications": {
     "IsEnabled": false
   },
+  "Worker": {
+    "DefaultTimeZone": "America/Chicago"
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console" ],
     "MinimumLevel": "Information",


### PR DESCRIPTION
Due to containerized apps typically running in UTC, the time on captured tracking updates was typically incorrect. This worked circumstantially when developing locally, due to the worker running in local time. This addresses the issue when running in a containerized environment by adding a function to process a date into the correct time. By calling `parseDate(text, location)` in a script, the app will now parse the provided date as if it were a time in a specific time zone. In the future, this should use geocoding. For now, it uses a system default time zone. There may still be inconsistencies when using the app across time zones.