### PR TITLE
Link Packages to Carrier Executions

### DIFF
--- a/src/EtherGizmos.Shipyard.Api/Controllers/PackagesController.cs
+++ b/src/EtherGizmos.Shipyard.Api/Controllers/PackagesController.cs
@@ -150,6 +150,7 @@ public class PackagesController : AutoODataController
         var execution = new CarrierExecution()
         {
             CarrierId = package.CarrierId,
+            PackageId = package.Id,
             ExecutionStatus = ExecutionStatusType.Queued,
             StepCount = (short)package.Carrier.Steps.Count,
         };

--- a/src/EtherGizmos.Shipyard.Database/EtherGizmos.Shipyard.Database.csproj
+++ b/src/EtherGizmos.Shipyard.Database/EtherGizmos.Shipyard.Database.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/src/EtherGizmos.Shipyard.Database/Migrations/00/00/Feature000083/Migration001_AddPackageToCarrierExecutions.cs
+++ b/src/EtherGizmos.Shipyard.Database/Migrations/00/00/Feature000083/Migration001_AddPackageToCarrierExecutions.cs
@@ -1,0 +1,25 @@
+﻿using EtherGizmos.Shipyard.Migrations.Core;
+using FluentMigrator;
+
+namespace EtherGizmos.Shipyard.Migrations._00._00.Feature000083;
+
+[CreatedAt(year: 2025, month: 11, day: 26, hour: 15, minute: 00, description: "Add package to carrier executions")]
+public class Migration001_AddPackageToCarrierExecutions : AutoReversingMigration
+{
+    public override void Up()
+    {
+        Create.Column("package_id")
+            .OnTable("carrier_executions")
+            .AsInt32()
+            .Nullable();
+
+        Create.ForeignKey("FK_carrier_executions_package_id")
+            .FromTable("carrier_executions").ForeignColumn("package_id")
+            .ToTable("packages").PrimaryColumn("package_id");
+
+        Create.Index("IX_carrier_executions_package_id")
+            .OnTable("carrier_executions")
+            .OnColumn("package_id")
+            .Ascending();
+    }
+}

--- a/src/EtherGizmos.Shipyard.Database/Models/CarrierExecutionConfiguration.cs
+++ b/src/EtherGizmos.Shipyard.Database/Models/CarrierExecutionConfiguration.cs
@@ -26,6 +26,13 @@ public class CarrierExecutionConfiguration : IEntityTypeConfiguration<CarrierExe
             .WithMany()
             .HasForeignKey(e => e.CarrierId);
 
+        entity.Property(e => e.PackageId)
+            .HasColumnName("package_id");
+
+        entity.HasOne(e => e.Package)
+            .WithMany()
+            .HasForeignKey(e => e.PackageId);
+
         entity.Property(e => e.StartedAt)
             .HasColumnName("started_at_utc");
 

--- a/src/EtherGizmos.Shipyard.Database/Services/ApplicationContext.cs
+++ b/src/EtherGizmos.Shipyard.Database/Services/ApplicationContext.cs
@@ -107,7 +107,7 @@ public class ApplicationContext : DbContext
         // Add Query Filters
 
         modelBuilder.Entity<CarrierExecution>()
-            .HasQueryFilter(record => record.PackageId == null || AclPackages.Any(acl =>
+            .HasQueryFilter(record => AclPackages.Any(acl =>
                 _userContext.UserId != null
                 && acl.PrincipalUserId == _userContext.UserId
                 && acl.PermissionId == PermissionId.Read

--- a/src/EtherGizmos.Shipyard.Database/Services/ApplicationContext.cs
+++ b/src/EtherGizmos.Shipyard.Database/Services/ApplicationContext.cs
@@ -106,6 +106,14 @@ public class ApplicationContext : DbContext
         //**********************************************************
         // Add Query Filters
 
+        modelBuilder.Entity<CarrierExecution>()
+            .HasQueryFilter(record => record.PackageId == null || AclPackages.Any(acl =>
+                _userContext.UserId != null
+                && acl.PrincipalUserId == _userContext.UserId
+                && acl.PermissionId == PermissionId.Read
+                && acl.IsGrant == 1
+                && acl.PackageId == record.PackageId));
+
         modelBuilder.Entity<Group>()
             .HasQueryFilter(record => AclGroups.Any(acl =>
                 _userContext.UserId != null

--- a/src/EtherGizmos.Shipyard.Models/Api/CarrierExecutionDTO.cs
+++ b/src/EtherGizmos.Shipyard.Models/Api/CarrierExecutionDTO.cs
@@ -19,6 +19,10 @@ public class CarrierExecutionDTO
 
     public CarrierDTO? Carrier { get; set; }
 
+    public int? PackageId { get; set; }
+
+    public PackageDTO? Package { get; set; }
+
     public DateTimeOffset? StartedAt { get; set; }
 
     public DateTimeOffset? CompletedAt { get; set; }
@@ -45,6 +49,8 @@ public class CarrierExecutionDTOProfile : Profile
         /*  End Audit  */
         toDto.MapMember(dest => dest.CarrierId, src => src.CarrierId);
         toDto.MapMember(dest => dest.Carrier, src => src.Carrier, opt => opt.ExplicitExpansion());
+        toDto.MapMember(dest => dest.PackageId, src => src.PackageId);
+        toDto.MapMember(dest => dest.Package, src => src.Package, opt => opt.ExplicitExpansion());
         toDto.MapMember(dest => dest.StartedAt, src => src.StartedAt);
         toDto.MapMember(dest => dest.CompletedAt, src => src.CompletedAt);
         toDto.MapMember(dest => dest.ExecutionStatusType, src => src.ExecutionStatus);

--- a/src/EtherGizmos.Shipyard.Models/Database/CarrierExecution.cs
+++ b/src/EtherGizmos.Shipyard.Models/Database/CarrierExecution.cs
@@ -11,6 +11,10 @@ public class CarrierExecution : Auditable, IEntity
 
     public virtual Carrier Carrier { get; set; } = null!;
 
+    public virtual int? PackageId { get; set; }
+
+    public virtual Package? Package { get; set; }
+
     public virtual DateTimeOffset? StartedAt { get; set; }
 
     public virtual DateTimeOffset? CompletedAt { get; set; }

--- a/src/EtherGizmos.Shipyard.OData/Models/CarrierExecutionDTOConfiguration.cs
+++ b/src/EtherGizmos.Shipyard.OData/Models/CarrierExecutionDTOConfiguration.cs
@@ -33,6 +33,8 @@ public class CarrierExecutionDTOConfiguration : IModelConfiguration
             /*  End Audit  */
             entity.Property(e => e.CarrierId);
             entity.HasRequired(e => e.Carrier);
+            entity.Property(e => e.PackageId);
+            entity.HasOptional(e => e.Package);
             entity.Property(e => e.StartedAt);
             entity.Property(e => e.CompletedAt);
             entity.EnumProperty(e => e.ExecutionStatusType);

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/carrier/models/carrier-execution.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/carrier/models/carrier-execution.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { DateTimeZ } from "../../../shared/types/datetime/datetime";
 import { formFactoryForModel } from "../../../shared/utilities/form/form.util";
+import { PackageZ } from "../../package/models/package";
 import { CarrierZ } from "./carrier";
 import { carrierExecutionArtifactForm, CarrierExecutionArtifactZ } from "./carrier-execution-artifact";
 import { ExecutionStatusType } from "./execution-status-type";
@@ -11,6 +12,8 @@ export const CarrierExecutionZ = z.object({
   modifiedAt: DateTimeZ,
   carrierId: z.number().int(),
   carrier: z.lazy(() => CarrierZ).nullish(),
+  packageId: z.number().int().nullish(),
+  package: z.lazy(() => PackageZ).nullish(),
   startedAt: DateTimeZ.nullish(),
   completedAt: DateTimeZ.nullish(),
   executionStatusType: z.nativeEnum(ExecutionStatusType),
@@ -21,13 +24,14 @@ export const CarrierExecutionZ = z.object({
 
 export interface CarrierExecution extends z.infer<typeof CarrierExecutionZ> { }
 
-export type CarrierExecutionF = Omit<CarrierExecution, "carrier">;
+export type CarrierExecutionF = Omit<CarrierExecution, "carrier" | "package">;
 
 export const carrierExecutionForm = formFactoryForModel<CarrierExecutionF>(($form, model) => ({
   id: [model.id],
   createdAt: [model.createdAt],
   modifiedAt: [model.modifiedAt],
   carrierId: [model.carrierId],
+  packageId: [model.packageId],
   startedAt: [model.startedAt],
   completedAt: [model.completedAt],
   executionStatusType: [model.executionStatusType],

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/home/pages/dashboard/dashboard.component.html
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/home/pages/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="row">
   <!-- Header -->
   <detail-header text="Dashboard"
-                 subtext="Overview of your tracked packages and system state"
+                 subtext="Overview of your tracked packages and system state."
                  class="mt-3" />
 </div>
 

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/package.routes.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/package.routes.ts
@@ -64,4 +64,29 @@ export const PACKAGE_ROUTES: ExtendedRoute[] = [
       ],
     },
   },
+  {
+    path: ":packageId/executions",
+    pathMatch: "full",
+    loadComponent: () => import("./pages/package-execution-list/package-execution-list.component").then(m => m.PackageExecutionListComponent),
+    canActivate: [
+      authorizationGuard(SecurableType.Package, PermissionId.Read),
+      authorizationGuard(SecurableType.Carrier, PermissionId.Read),
+    ],
+    data: {
+      breadcrumb: {
+        label: "Execution List",
+        link: "/packages/{packageId}/executions",
+      },
+      parentBreadcrumbs: [
+        {
+          label: "Package List",
+          link: "/packages",
+        },
+        {
+          label: "Package #{packageId}",
+          link: "/packages/{packageId}",
+        },
+      ],
+    },
+  },
 ];

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.html
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.html
@@ -127,6 +127,7 @@
   </div>
 </div>
 
+@if (canViewCarriers$$()) {
 <!-- Last execution -->
 <div class="row">
   <div class="col-12 mt-3">
@@ -199,6 +200,7 @@
     </detail-box>
   </div>
 </div>
+}
 
 <!-- Tracking History -->
 <div class="row">

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.html
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.html
@@ -127,6 +127,79 @@
   </div>
 </div>
 
+<!-- Last execution -->
+<div class="row">
+  <div class="col-12 mt-3">
+    <detail-box icon="bi-code" text="Last Execution" [buttons]="execButtons$$()">
+      @let exec = exec$$();
+      @if (exec) {
+      <div class="row">
+        @let statusMeta = getExecutionStatusMetadata(exec.executionStatusType);
+        <div class="col-md-6">
+          <div class="row mt-3">
+            <label for="status" class="col-sm-4 col-form-label">
+              Status
+            </label>
+            <div class="col-sm-8">
+              <ng-select id="execStatus" [ngModel]="1" [ngModelOptions]="{ standalone: true }" [readonly]="true" [readonlyForm]="true">
+                <ng-option [value]="1">
+                  <span class="bi me-1" [class]="[statusMeta.icon, statusMeta.color]"></span>
+                  {{statusMeta.label}}
+                </ng-option>
+              </ng-select>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <div class="row mt-3">
+            <label for="execStartedAt" class="col-sm-4 col-form-label">
+              Started at
+            </label>
+            <div class="col-sm-8">
+              <input id="execStartedAt" type="text" [value]="exec.startedAt?.toLocaleString({ month: '2-digit', day: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }) ?? '—'" [readonlyForm]="true" />
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <div class="row">
+
+        <div class="col-md-6">
+          <div class="row mt-3">
+            <label for="execDuration" class="col-sm-4 col-form-label">
+              Duration
+            </label>
+            <div class="col-sm-8">
+              <input id="execDuration" type="text" [value]="getDiffTime(exec.startedAt, exec.completedAt)" [readonlyForm]="true" />
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <div class="row mt-3">
+            <label for="execArtifacts" class="col-sm-4 col-form-label">
+              Artifacts
+            </label>
+            <div class="col-sm-8">
+              <input id="execArtifacts" type="text" [value]="exec.artifacts.length" [readonlyForm]="true" />
+            </div>
+          </div>
+        </div>
+
+      </div>
+      } @else {
+      <div class="row">
+        <div class="col-12 mt-3">
+          No recent executions
+        </div>
+      </div>
+      }
+    </detail-box>
+  </div>
+</div>
+
 <!-- Tracking History -->
 <div class="row">
   <div class="col-12 mt-3">

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.ts
@@ -185,29 +185,31 @@ export class PackageDetailComponent implements OnInit {
       this.package$$.set(data);
       this.init();
 
-      try {
-        this.isLoadingExecStack$$.set(this.isLoadingExecStack$$() + 1);
+      if (this.$session.hasCapability(SecurableType.Carrier, PermissionId.Read)) {
+        try {
+          this.isLoadingExecStack$$.set(this.isLoadingExecStack$$() + 1);
 
-        const exec = await this.$carrierExecution.search()
-          .filter(e =>
-            o.and(
-              o.eq(
-                e.prop("packageId"),
-                o.int(id)
-              ),
-              o.ne(
-                e.prop("startedAt"),
-                o.null()
+          const exec = await this.$carrierExecution.search()
+            .filter(e =>
+              o.and(
+                o.eq(
+                  e.prop("packageId"),
+                  o.int(id)
+                ),
+                o.ne(
+                  e.prop("startedAt"),
+                  o.null()
+                )
               )
             )
-          )
-          .orderBy("startedAt", "desc")
-          .execute()
-          .data;
+            .orderBy("startedAt", "desc")
+            .execute()
+            .data;
 
-        this.exec$$.set(exec[0]);
-      } finally {
-        this.isLoadingExecStack$$.set(this.isLoadingExecStack$$() - 1);
+          this.exec$$.set(exec[0]);
+        } finally {
+          this.isLoadingExecStack$$.set(this.isLoadingExecStack$$() - 1);
+        }
       }
     } finally {
       this.isLoadingStack$$.set(this.isLoadingStack$$() - 1);

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-detail/package-detail.component.ts
@@ -3,14 +3,19 @@ import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { EntitySingle } from '@ethergizmos/odata-fluent-client';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { DetailBoxComponent } from '../../../../shared/components/detail-box/detail-box.component';
+import { DateTime, Duration } from 'luxon';
+import { DetailBoxButton, DetailBoxComponent } from '../../../../shared/components/detail-box/detail-box.component';
 import { DetailHeaderComponent } from '../../../../shared/components/detail-header/detail-header.component';
 import { ReadonlyFormDirective } from '../../../../shared/directives/readonly-form/readonly-form.directive';
 import { NavbarActionService } from '../../../../shared/services/navbar-action/navbar-action.service';
 import { Bound } from '../../../../shared/utilities/bound/bound.util';
 import { getDirtyFormValues, TypedFormGroup } from '../../../../shared/utilities/form/form.util';
+import { o } from '../../../../shared/utilities/odata/odata.util';
 import { NavbarAction } from '../../../app/components/navbar-action/navbar-action.component';
 import { Carrier } from '../../../carrier/models/carrier';
+import { CarrierExecution } from '../../../carrier/models/carrier-execution';
+import { ExecutionStatusType, getExecutionStatusTypeMetadata } from '../../../carrier/models/execution-status-type';
+import { CarrierExecutionService } from '../../../carrier/services/carrier-execution/carrier-execution.service';
 import { CarrierService } from '../../../carrier/services/carrier/carrier.service';
 import { UserSessionService } from '../../../login/services/user-session/user-session.service';
 import { PermissionId } from '../../../security/models/permission-id';
@@ -37,6 +42,7 @@ export class PackageDetailComponent implements OnInit {
 
   private readonly $package = inject(PackageService);
   private readonly $carrier = inject(CarrierService);
+  private readonly $carrierExecution = inject(CarrierExecutionService);
   private readonly $form = inject(FormBuilder);
   private readonly $navbarAction = inject(NavbarActionService);
   private readonly $route = inject(ActivatedRoute);
@@ -52,6 +58,11 @@ export class PackageDetailComponent implements OnInit {
 
   readonly isLoading$$ = computed(() => this.isLoadingStack$$() > 0);
   private readonly isLoadingStack$$ = signal(0);
+
+  readonly exec$$ = signal<CarrierExecution | undefined>(undefined);
+
+  readonly isLoadingExec$$ = computed(() => this.isLoadingExecStack$$() > 0);
+  private readonly isLoadingExecStack$$ = signal(0);
 
   readonly isEditing$$ = signal(false);
 
@@ -100,6 +111,20 @@ export class PackageDetailComponent implements OnInit {
     }
 
     return actions;
+  });
+
+  readonly execButtons$$ = computed<DetailBoxButton[]>(() => {
+    const buttons: DetailBoxButton[] = [];
+
+    if (!this.isEditing$$()) {
+      buttons.push({
+        color: "primary",
+        text: "View all",
+        callback: this.viewExecutions,
+      });
+    }
+
+    return buttons;
   });
 
   get trackingUpdates() {
@@ -160,8 +185,29 @@ export class PackageDetailComponent implements OnInit {
       this.package$$.set(data);
       this.init();
 
-      if (this.carriers$$().length === 0) {
-        this.carriers$$.set([data.carrier!]);
+      try {
+        this.isLoadingExecStack$$.set(this.isLoadingExecStack$$() + 1);
+
+        const exec = await this.$carrierExecution.search()
+          .filter(e =>
+            o.and(
+              o.eq(
+                e.prop("packageId"),
+                o.int(id)
+              ),
+              o.ne(
+                e.prop("startedAt"),
+                o.null()
+              )
+            )
+          )
+          .orderBy("startedAt", "desc")
+          .execute()
+          .data;
+
+        this.exec$$.set(exec[0]);
+      } finally {
+        this.isLoadingExecStack$$.set(this.isLoadingExecStack$$() - 1);
       }
     } finally {
       this.isLoadingStack$$.set(this.isLoadingStack$$() - 1);
@@ -245,5 +291,31 @@ export class PackageDetailComponent implements OnInit {
     } else {
       this.$router.navigate(["/packages"]);
     }
+  }
+
+  getExecutionStatusMetadata(statusType: ExecutionStatusType) {
+    return getExecutionStatusTypeMetadata(statusType);
+  }
+
+  getDiffTime(dateTime1: DateTime | null | undefined, dateTime2: DateTime | null | undefined) {
+    if (!dateTime1 || !dateTime2)
+      return "—";
+
+    let duration = Duration.fromMillis(dateTime2.toMillis() - dateTime1.toMillis())
+      .shiftTo("hours", "minutes", "seconds");
+
+    if (duration.hours === 0) {
+      duration = duration.shiftTo("minutes", "seconds");
+
+      if (duration.minutes === 0) {
+        duration = duration.shiftTo("seconds");
+      }
+    }
+
+    return duration.toHuman({ unitDisplay: "short" }).split(",")[0];
+  }
+
+  @Bound viewExecutions() {
+    this.$router.navigate(["/packages", this.id$$(), "executions"]);
   }
 }

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-execution-list/package-execution-list.component.html
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-execution-list/package-execution-list.component.html
@@ -1,0 +1,85 @@
+<!-- Header -->
+<div class="row">
+  <div class="col-12 mt-3">
+
+    <detail-header text="Execution History"
+                   subtext="View recent executions for package #{{id}}." />
+
+  </div>
+</div>
+
+<!-- Table -->
+<div class="row">
+  <div class="col-12 mt-3">
+
+    <detail-box icon="bi-code"
+                text="Executions List">
+      <div class="mt-3">
+        <app-table [data]="records" [minRows]="perPage" [isLoading]="isLoading()"
+                   [sort]="activeSort" (sortChange)="onSortChange($event)"
+                   (filterChange)="onFilterChange($event)">
+          <ng-template #headers>
+            <th app-table-header="carrier/name" class="text-nowrap"
+                type="string"
+                [sortable]="false"
+                [filterable]="false">
+              Carrier name
+            </th>
+            <th app-table-header="startedAt" class="text-nowrap"
+                type="datetime"
+                [sortable]="true"
+                [filterable]="true">
+              Started at
+            </th>
+            <th app-table-header="duration" class="text-nowrap"
+                type="datetime"
+                [sortable]="false"
+                [filterable]="false">
+              Duration
+            </th>
+            <th app-table-header="executionStatusType" class="text-nowrap"
+                type="string"
+                [sortable]="true"
+                [filterable]="true">
+              Status
+            </th>
+            <th class="text-nowrap">
+              Actions
+            </th>
+          </ng-template>
+
+          <ng-template #rows let-row>
+            @let statusMeta = getExecutionStatusMetadata(row.executionStatusType);
+            <td class="text-nowrap">
+              {{row.carrier?.name ?? 'Unknown'}}
+            </td>
+            <td class="text-nowrap">
+              {{row.startedAt?.startOf('minute')?.toLocaleString({ month: '2-digit', day: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }) ?? 'Never'}}
+            </td>
+            <td class="text-nowrap">
+              {{getDiffTime(row.startedAt, row.completedAt)}}
+            </td>
+            <td class="text-nowrap">
+              <span class="bi" [class]="[statusMeta.icon, statusMeta.color]"></span>
+              {{statusMeta.label}}
+            </td>
+            <td class="text-nowrap">
+              <a [routerLink]="['/carriers/', row.carrierId, 'executions', row.id]" [queryParams]="{append: 1}">View</a>
+            </td>
+          </ng-template>
+        </app-table>
+      </div>
+      <div class="mt-3 d-flex justify-content-center">
+        <ngb-pagination [collectionSize]="count"
+                        [pageSize]="perPage"
+                        [page]="page"
+                        (pageChange)="page = $event; search()"
+                        [maxSize]="5"
+                        [rotate]="true"
+                        [boundaryLinks]="true"
+                        [directionLinks]="true"></ngb-pagination>
+      </div>
+    </detail-box>
+
+  </div>
+</div>

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-execution-list/package-execution-list.component.spec.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-execution-list/package-execution-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PackageExecutionListComponent } from './package-execution-list.component';
+
+describe('PackageExecutionListComponent', () => {
+  let component: PackageExecutionListComponent;
+  let fixture: ComponentFixture<PackageExecutionListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PackageExecutionListComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PackageExecutionListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-execution-list/package-execution-list.component.ts
+++ b/src/EtherGizmos.Shipyard.Web/src/app/features/package/pages/package-execution-list/package-execution-list.component.ts
@@ -1,0 +1,113 @@
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { EntitySet } from '@ethergizmos/odata-fluent-client';
+import { NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
+import { DateTime, Duration } from 'luxon';
+import { ListComponent, TableColumn } from '../../../../shared/components/_base/list/list.component';
+import { DetailBoxComponent } from '../../../../shared/components/detail-box/detail-box.component';
+import { DetailHeaderComponent } from '../../../../shared/components/detail-header/detail-header.component';
+import { TableHeaderComponent } from '../../../../shared/components/table-header/table-header.component';
+import { TableComponent } from '../../../../shared/components/table/table.component';
+import { o } from '../../../../shared/utilities/odata/odata.util';
+import { SortColumn } from '../../../../shared/utilities/sort/sort.util';
+import { NavbarAction } from '../../../app/components/navbar-action/navbar-action.component';
+import { CarrierExecution } from '../../../carrier/models/carrier-execution';
+import { ExecutionStatusType, getExecutionStatusTypeMetadata } from '../../../carrier/models/execution-status-type';
+import { CarrierExecutionService } from '../../../carrier/services/carrier-execution/carrier-execution.service';
+
+@Component({
+  selector: 'app-package-execution-list',
+  imports: [
+    DetailBoxComponent,
+    DetailHeaderComponent,
+    NgbPaginationModule,
+    RouterModule,
+    TableComponent,
+    TableHeaderComponent,
+  ],
+  templateUrl: './package-execution-list.component.html',
+  styleUrl: './package-execution-list.component.scss',
+})
+export class PackageExecutionListComponent extends ListComponent<CarrierExecution> {
+
+  private readonly $carrierExecution = inject(CarrierExecutionService);
+  private readonly $activatedRoute = inject(ActivatedRoute);
+  private readonly $router = inject(Router);
+
+  protected id!: number;
+
+  override readonly perPage: number = 10;
+
+  override activeSort: SortColumn = {
+    column: "startedAt",
+    direction: "desc",
+  };
+
+  override ngOnInit() {
+    this.id = parseInt(this.$activatedRoute.snapshot.paramMap.get("packageId")!);
+
+    super.ngOnInit();
+  }
+
+  protected override get actions(): NavbarAction[] {
+    const actions: NavbarAction[] = [
+
+    ];
+
+    if (!this.isLoading()) {
+      //actions.push({
+      //  icon: 'bi-layout-three-columns',
+      //  label: 'Edit Columns',
+      //});
+    }
+
+    return actions;
+  }
+
+  protected override get columns(): TableColumn[] {
+    const columns: TableColumn[] = [];
+
+    return columns;
+  }
+
+  protected override getEntitySet(): EntitySet<CarrierExecution> {
+    return this.$carrierExecution.search()
+      .filter(e =>
+        o.and(
+          o.eq(
+            e.prop("packageId"),
+            o.int(this.id)
+          ),
+          o.ne(
+            e.prop("startedAt"),
+            o.null()
+          )
+        )
+      )
+      .expand("carrier", e => e
+        .select("id", "name")
+      );
+  }
+
+  getExecutionStatusMetadata(statusType: ExecutionStatusType) {
+    return getExecutionStatusTypeMetadata(statusType);
+  }
+
+  getDiffTime(dateTime1: DateTime | null | undefined, dateTime2: DateTime | null | undefined) {
+    if (!dateTime1 || !dateTime2)
+      return "—";
+
+    let duration = Duration.fromMillis(dateTime2.toMillis() - dateTime1.toMillis())
+      .shiftTo("hours", "minutes", "seconds");
+
+    if (duration.hours === 0) {
+      duration = duration.shiftTo("minutes", "seconds");
+
+      if (duration.minutes === 0) {
+        duration = duration.shiftTo("seconds");
+      }
+    }
+
+    return duration.toHuman({ unitDisplay: "short" }).split(",")[0];
+  }
+}

--- a/src/EtherGizmos.Shipyard.Worker/Services/HostedServices/QueueTrackingRequestBackgroundService.cs
+++ b/src/EtherGizmos.Shipyard.Worker/Services/HostedServices/QueueTrackingRequestBackgroundService.cs
@@ -48,6 +48,7 @@ public class QueueTrackingRequestBackgroundService : PeriodicBackgroundService
             var execution = new CarrierExecution()
             {
                 CarrierId = package.CarrierId,
+                PackageId = package.Id,
                 ExecutionStatus = ExecutionStatusType.Queued,
                 StepCount = (short)package.Carrier.Steps.Count,
             };

--- a/tests/EtherGizmos.Shipyard.Api.IntegrationTests/Controllers/Specifications/CarrierExecutionsControllerV1Spec.cs
+++ b/tests/EtherGizmos.Shipyard.Api.IntegrationTests/Controllers/Specifications/CarrierExecutionsControllerV1Spec.cs
@@ -61,6 +61,7 @@ public class CarrierExecutionsControllerV1Spec : IODataResourceSpec<CarrierExecu
             Guid? createdByUserId = null)
         {
             var (_, id) = await CarriersControllerV1Spec.Instance.Records.AcquireAsync(context, purpose, createdByUserId);
+            var (_, packageId) = await PackagesControllerV1Spec.Instance.Records.AcquireAsync(context, purpose, createdByUserId);
 
             var uowFactory = Setup.Services.GetRequiredService<IUnitOfWorkFactory>();
             using var uow = uowFactory.Create();
@@ -70,6 +71,7 @@ public class CarrierExecutionsControllerV1Spec : IODataResourceSpec<CarrierExecu
             var execution = new CarrierExecution()
             {
                 CarrierId = id,
+                PackageId = packageId,
                 StepCount = 1,
                 ExecutionStatus = ExecutionStatusType.Successful,
             };


### PR DESCRIPTION
Adds a reference from carrier executions to their associated package. This makes carrier executions group-specific, since they reference group-specific data. Additionally, adds a page for viewing recent executions for a package.