### PR TITLE
Fix Case Sensitivity in PostgreSQL

### DIFF
--- a/src/EtherGizmos.Shipyard.Database/EtherGizmos.Shipyard.Database.csproj
+++ b/src/EtherGizmos.Shipyard.Database/EtherGizmos.Shipyard.Database.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EtherGizmos.Shipyard.Database/IServiceCollectionExtensions.cs
+++ b/src/EtherGizmos.Shipyard.Database/IServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using EtherGizmos.Shipyard.Configuration;
 using EtherGizmos.Shipyard.Migrations.Core;
 using EtherGizmos.Shipyard.Services;
 using FluentMigrator.Runner;
+using FluentMigrator.Runner.Generators.Postgres;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -74,6 +75,9 @@ public static class IServiceCollectionExtensions
                                 .WithGlobalConnectionString(postgreSql.ConnectionString)
                         );
                     });
+
+                child.Decorate<IPostgresTypeMap, PostgresTypeMap>();
+                child.Decorate<Postgres15_0Generator, CustomPostgresGenerator>();
             })
             .ImportLogging()
             .ForwardScoped<IMigrationRunner>();

--- a/src/EtherGizmos.Shipyard.Database/Migrations/00/01/Feature000150/Migration001_EnableCitextExtension.cs
+++ b/src/EtherGizmos.Shipyard.Database/Migrations/00/01/Feature000150/Migration001_EnableCitextExtension.cs
@@ -1,0 +1,29 @@
+﻿using EtherGizmos.Shipyard.Migrations.Core;
+using FluentMigrator;
+using Npgsql;
+
+namespace EtherGizmos.Shipyard.Migrations._00._01.Feature000150;
+
+[CreatedAt(year: 2025, month: 01, day: 01, hour: 00, minute: 00, description: "Enable citext extension", trackingId: 150)]
+public class Migration001_EnableCitextExtension : MigrationExtension
+{
+    public override void Up()
+    {
+        IfDatabase(ProcessorIdConstants.PostgreSQL)
+            .Execute.Sql("""
+                create extension if not exists citext;
+                """);
+
+        Execute.WithConnection((conn, tran) =>
+        {
+            if (conn is NpgsqlConnection npgsql)
+            {
+                npgsql.ReloadTypes();
+            }
+        });
+    }
+
+    public override void Down()
+    {
+    }
+}

--- a/src/EtherGizmos.Shipyard.Database/Migrations/00/01/Feature000150/Migration001_FixPostgresCaseSensitivity.cs
+++ b/src/EtherGizmos.Shipyard.Database/Migrations/00/01/Feature000150/Migration001_FixPostgresCaseSensitivity.cs
@@ -1,0 +1,37 @@
+﻿using EtherGizmos.Shipyard.Migrations.Core;
+using FluentMigrator;
+
+namespace EtherGizmos.Shipyard.Migrations._00._01.Feature000150;
+
+[CreatedAt(year: 2025, month: 11, day: 29, hour: 13, minute: 30, description: "Fix PostgreSQL case sensitivity", trackingId: 150)]
+public class Migration001_FixPostgresCaseSensitivity : MigrationExtension
+{
+    public override void Up()
+    {
+        IfDatabase(ProcessorIdConstants.PostgreSQL)
+            .Execute.Sql("""
+                do $$
+                declare r record;
+                begin
+                  for r in
+                    select table_schema,
+                      table_name,
+                      column_name
+                      from information_schema.columns
+                      where table_schema in ( 'public', 'oauth2', 'acl' )
+                        and data_type in ( 'character varying', 'text' )
+                        and table_name not in ( 'migration_history' )
+                  loop
+                    execute format(
+                      'alter table %I.%I alter column %I type citext',
+                      r.table_schema, r.table_name, r.column_name
+                    );
+                  end loop;
+                end $$;
+                """);
+    }
+
+    public override void Down()
+    {
+    }
+}

--- a/src/EtherGizmos.Shipyard.Database/Services/CustomPostgresColumn.cs
+++ b/src/EtherGizmos.Shipyard.Database/Services/CustomPostgresColumn.cs
@@ -1,0 +1,48 @@
+﻿using FluentMigrator.Model;
+using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Generators.Base;
+using FluentMigrator.Runner.Generators.Postgres;
+using System.Reflection;
+
+namespace EtherGizmos.Shipyard.Services;
+
+internal class CustomPostgresColumn : ColumnBase<IPostgresTypeMap>
+{
+    private readonly ColumnBase<IPostgresTypeMap> _inner;
+
+    [Obsolete]
+    public CustomPostgresColumn(
+        ColumnBase<IPostgresTypeMap> inner,
+        IPostgresTypeMap typeMap,
+        IQuoter quoter)
+        : base(typeMap, quoter)
+    {
+        _inner = inner;
+    }
+
+    protected override string FormatIdentity(ColumnDefinition column)
+        => (string)typeof(ColumnBase<IPostgresTypeMap>)
+            .GetMethod(nameof(FormatIdentity), BindingFlags.NonPublic | BindingFlags.Instance, [typeof(ColumnDefinition)])!
+            .Invoke(_inner, [column])!;
+
+    protected override string FormatType(ColumnDefinition column)
+    {
+        //Don't use custom types for [migration_history]
+        if (column.TableName == "migration_history")
+            return (string)typeof(ColumnBase<IPostgresTypeMap>)
+                .GetMethod(nameof(FormatType), BindingFlags.NonPublic | BindingFlags.Instance, [typeof(ColumnDefinition)])!
+                .Invoke(_inner, [column])!;
+
+        return base.FormatType(column);
+    }
+
+    public virtual string GenerateAlterClauses(ColumnDefinition column)
+        => (string)_inner.GetType()
+            .GetMethod(nameof(GenerateAlterClauses), BindingFlags.Public | BindingFlags.Instance, [typeof(ColumnDefinition)])!
+            .Invoke(_inner, [column])!;
+
+    public virtual string FormatAlterDefaultValue(string column, object defaultValue)
+        => (string)_inner.GetType()
+            .GetMethod(nameof(FormatAlterDefaultValue), BindingFlags.Public | BindingFlags.Instance, [typeof(string), typeof(object)])!
+            .Invoke(_inner, [column, defaultValue])!;
+}

--- a/src/EtherGizmos.Shipyard.Database/Services/CustomPostgresGenerator.cs
+++ b/src/EtherGizmos.Shipyard.Database/Services/CustomPostgresGenerator.cs
@@ -1,0 +1,81 @@
+﻿using FluentMigrator.Expressions;
+using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Generators.Base;
+using FluentMigrator.Runner.Generators.Postgres;
+using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+
+namespace EtherGizmos.Shipyard.Services;
+
+internal class CustomPostgresGenerator : Postgres15_0Generator
+{
+    [Obsolete]
+    public CustomPostgresGenerator(
+        Postgres15_0Generator inner,
+        IPostgresTypeMap typeMap,
+        IOptions<GeneratorOptions> generatorOptions)
+        : this(GetColumn(inner, typeMap), GetQuoter(inner), generatorOptions)
+    {
+    }
+
+    protected CustomPostgresGenerator(IColumn column, PostgresQuoter quoter, IOptions<GeneratorOptions> generatorOptions) : base(column, quoter, generatorOptions)
+    {
+    }
+
+    [Obsolete]
+    private static ColumnBase<IPostgresTypeMap> GetColumn(
+        GeneratorBase inner,
+        IPostgresTypeMap typeMap)
+    {
+        var column = (ColumnBase<IPostgresTypeMap>)typeof(GeneratorBase)
+            .GetProperty(nameof(Column), BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(inner)!;
+
+        return new CustomPostgresColumn(column, typeMap, GetQuoter(inner));
+    }
+
+    [Obsolete]
+    private static PostgresQuoter GetQuoter(
+        GeneratorBase inner)
+    {
+        var quoter = (PostgresQuoter)typeof(GeneratorBase)
+            .GetProperty(nameof(Quoter), BindingFlags.Public | BindingFlags.Instance)!
+            .GetValue(inner)!;
+
+        return quoter;
+    }
+
+    [ExcludeFromCodeCoverage]
+    public override string Generate(AlterColumnExpression expression)
+    {
+        var alterStatement = new StringBuilder();
+        alterStatement.AppendFormat(
+            AlterColumn,
+            Quoter.QuoteTableName(expression.TableName, expression.SchemaName),
+            ((CustomPostgresColumn)Column).GenerateAlterClauses(expression.Column));
+
+        AppendSqlStatementEndToken(alterStatement);
+
+        var descriptionStatement = DescriptionGenerator.GenerateDescriptionStatement(expression);
+
+        if (!string.IsNullOrEmpty(descriptionStatement))
+        {
+            alterStatement.Append(descriptionStatement);
+            AppendSqlStatementEndToken(alterStatement);
+        }
+
+        return alterStatement.ToString();
+    }
+
+    [ExcludeFromCodeCoverage]
+    public override string Generate(AlterDefaultConstraintExpression expression)
+    {
+        return string.Format(
+            "ALTER TABLE {0} ALTER {1} DROP DEFAULT, ALTER {1} {2};",
+            Quoter.QuoteTableName(expression.TableName, expression.SchemaName),
+            Quoter.QuoteColumnName(expression.ColumnName),
+            ((CustomPostgresColumn)Column).FormatAlterDefaultValue(expression.ColumnName, expression.DefaultValue));
+    }
+}

--- a/src/EtherGizmos.Shipyard.Database/Services/PostgresTypeMap.cs
+++ b/src/EtherGizmos.Shipyard.Database/Services/PostgresTypeMap.cs
@@ -1,0 +1,27 @@
+﻿using FluentMigrator.Runner.Generators;
+using FluentMigrator.Runner.Generators.Postgres;
+using System.Data;
+
+namespace EtherGizmos.Shipyard.Services;
+
+internal class PostgresTypeMap : IPostgresTypeMap
+{
+    private readonly ITypeMap _inner;
+
+    public PostgresTypeMap(
+        ITypeMap inner)
+    {
+        _inner = inner;
+    }
+
+    public string GetTypeMap(
+        DbType type,
+        int? size,
+        int? precision)
+    {
+        if (type == DbType.String || type == DbType.AnsiString)
+            return "citext";
+
+        return _inner.GetTypeMap(type, size, precision);
+    }
+}

--- a/tests/EtherGizmos.Shipyard.Api.IntegrationTests/Controllers/Aspects/Entity/EntityAspects.cs
+++ b/tests/EtherGizmos.Shipyard.Api.IntegrationTests/Controllers/Aspects/Entity/EntityAspects.cs
@@ -7,7 +7,7 @@ public static class EntityAspects
     private static class Generic<TEntity, TId>
         where TEntity : class, new()
     {
-        public static IEnumerable<IAspect<TEntity, TId>> All 
+        public static IEnumerable<IAspect<TEntity, TId>> All
             =>
             [
                 new SearchAuthAspect<TEntity, TId>(),


### PR DESCRIPTION
Addresses an issue where fields stored in PostgreSQL were all case sensitive. This applied to searching in the app, logins, etc. A migration has been added to fix existing tables, while the column type used by string columns has been changed for future tables.